### PR TITLE
Allow callbacks as 'function' and 'filter'

### DIFF
--- a/ETwigViewRenderer.php
+++ b/ETwigViewRenderer.php
@@ -234,13 +234,13 @@ class ETwigViewRenderer extends CApplicationComponent implements IViewRenderer
             $twigElement = null;
 
             switch ($func) {
-                // Just a name of function
-                case is_string($func):
+                // Callable (including just a name of function).
+                case is_callable($func):
                     $twigElement = new $classFunction($func);
                 break;
-                // Name of function + options array
-                case is_array($func) && is_string($func[0]) && isset($func[1]) && is_array($func[1]):
-                    $twigElement = new $classFunction($func[0], $func[1]);
+                // Callable (including just a name of function) + options array.
+                case is_array($func) && is_callable($func[0]):
+                    $twigElement = new $classFunction($func[0], (!empty($func[1]) && is_array($func[1])) ? $func[1] : []);
                 break;
             }
 


### PR DESCRIPTION
I've found similar pull-request https://github.com/yiiext/twig-renderer/pull/13 , but it looks like it could be achived by much simpler approach.
This pull-request adds what it should: allows passing callbacks as `function` and `filter`. Also it fixes misbehavior (misunderstanding?) of working with `options` - they are not required, so we should not rely on them heavily, just pass them through if they are present.
