### PR TITLE
Remove deprecated Twig autoloader

### DIFF
--- a/ETwigViewRenderer.php
+++ b/ETwigViewRenderer.php
@@ -67,9 +67,6 @@ class ETwigViewRenderer extends CApplicationComponent implements IViewRenderer
 
     function init()
     {
-        require Yii::getPathOfAlias($this->twigPathAlias).'/Autoloader.php';
-        Yii::registerAutoloader(array('Twig_Autoloader', 'autoload'), true);
-
         $app = Yii::app();
 
         /** @var $theme CTheme */


### PR DESCRIPTION
According to https://github.com/twigphp/Twig/blob/1.x/lib/Twig/Autoloader.php the Autoloader is deprecated since composer should e able to handle all the class loads