### PR TITLE
Prepare code for Twig 2.0, and avoid error triggering

### DIFF
--- a/ETwigViewRenderer.php
+++ b/ETwigViewRenderer.php
@@ -101,7 +101,7 @@ class ETwigViewRenderer extends CApplicationComponent implements IViewRenderer
 
         // Adding global 'void' function (usage: {{void(App.clientScript.registerScriptFile(...))}})
         // (@see ETwigViewRendererVoidFunction below for details)
-        $this->_twig->addFunction('void', new Twig_Function_Function('ETwigViewRendererVoidFunction'));
+        $this->_twig->addFunction(new Twig_SimpleFunction('void', 'ETwigViewRendererVoidFunction'));
 
         // Adding custom globals (objects or static classes)
         if (!empty($this->globals)) {
@@ -228,7 +228,7 @@ class ETwigViewRenderer extends CApplicationComponent implements IViewRenderer
      */
     private function _addCustom($classType, $elements)
     {
-        $classFunction = 'Twig_'.$classType.'_Function';
+        $classFunction = 'Twig_Simple' . $classType;
 
         foreach ($elements as $name => $func) {
             $twigElement = null;
@@ -236,16 +236,16 @@ class ETwigViewRenderer extends CApplicationComponent implements IViewRenderer
             switch ($func) {
                 // Just a name of function
                 case is_string($func):
-                    $twigElement = new $classFunction($func);
+                    $twigElement = new $classFunction($name, $func);
                 break;
                 // Name of function + options array
                 case is_array($func) && is_string($func[0]) && isset($func[1]) && is_array($func[1]):
-                    $twigElement = new $classFunction($func[0], $func[1]);
+                    $twigElement = new $classFunction($name, $func[0], $func[1]);
                 break;
             }
 
             if ($twigElement !== null) {
-                $this->_twig->{'add'.$classType}($name, $twigElement);
+                $this->_twig->{'add'.$classType}($twigElement);
             } else {
                 throw new CException(Yii::t('yiiext',
                                              'Incorrect options for "{classType}" [{name}]',


### PR DESCRIPTION
Currently Twig spams the error handlers with "silent" trigger_errors due to deprecation notices.
This avoids them, by adapting the code to Twig 2.0 objects