### PR TITLE
Checking the existence getTheme

### DIFF
--- a/ETwigViewRenderer.php
+++ b/ETwigViewRenderer.php
@@ -73,7 +73,7 @@ class ETwigViewRenderer extends CApplicationComponent implements IViewRenderer
         $app = Yii::app();
 
         /** @var $theme CTheme */
-        $theme = $app->getTheme();
+        $theme = method_exists($app, 'getTheme') ? $app->getTheme() : null;
 
         $this->_paths = array();
 


### PR DESCRIPTION
Checking the existence getTheme method before calling, because in case render template at console mode instance of CConsoleApplication does not has getTheme method